### PR TITLE
chore:use c++17 innstall of c++14,support electron >20

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,7 @@
 				'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
 				'OTHER_CFLAGS': [
 					'-ObjC++',
-					'-std=c++14'
+					'-std=c++17'
 				]
 			    }
 			}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
 	"gypfile": true,
 	"dependencies": {
 		"@mapbox/node-pre-gyp": "^1.0.9",
-		"nan": "^2.13.2"
+		"nan": "^2.17.0"
 	}
 }


### PR DESCRIPTION
`nan` version needs to be updated synchronously
[https://github.com/electron/electron/issues/35193](https://github.com/electron/electron/issues/35193)